### PR TITLE
builtins has function foldl' and not foldl

### DIFF
--- a/fromYaml.nix
+++ b/fromYaml.nix
@@ -7,7 +7,10 @@
   # TODO: add support for multi line strings
  */
 {lib ? (import <nixpkgs> {}).lib, ...}: let
-  l = lib // builtins;
+  l = lib // builtins // {
+    # I'm going to cry on Nix's naming convention
+    foldl = lib.foldl or lib.foldl' or builtins.foldl or builtins.foldl';
+  };
 
   parse = text: let
     lines = l.splitString "\n" text;


### PR DESCRIPTION
From the [NixOS manual](https://nixos.org/manual/nix/unstable/language/builtins.html#builtins-foldl'), there exists a `foldl'` function but not `foldl`. I tested on my NixOS installation and indeed, `nix repl` complains about there not being a `foldl` function.

This PR substitute `l.foldl` with `foldl` or `fodl'` coming from either `lib` or `builtins`.